### PR TITLE
Update favicon image

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,7 @@ export const metadata = {
   title: "Axel Peytavin",
   description: "Bringing agentic robots to everyone",
   icons: {
-    icon: "/pp_yc.png",
+    icon: "/marin-mar-26.png",
   },
 };
 


### PR DESCRIPTION
## Summary
- point the site favicon to the new profile image asset

## Testing
- verified locally at http://localhost:3004 that the page head emits /marin-mar-26.png as the icon
- rebuilt and republished the Pages output